### PR TITLE
Add samplers for truncated log normal distributions

### DIFF
--- a/popsynth/aux_samplers/__init__.py
+++ b/popsynth/aux_samplers/__init__.py
@@ -7,6 +7,7 @@ from .plaw_aux_sampler import (
     PowerLawAuxSampler,
 )
 from .trunc_normal_aux_sampler import TruncatedNormalAuxSampler
+from .trunc_lognormal_aux_sampler import TruncatedLogNormalAuxSampler,TruncatedLog10NormalAuxSampler
 from .viewing_angle_sampler import ViewingAngleSampler
 
 __all__ = [
@@ -16,6 +17,8 @@ __all__ = [
     "Log10NormalAuxSampler",
     "NormalAuxSampler",
     "TruncatedNormalAuxSampler",
+    "TruncatedLogNormalAuxSampler",
+    "TruncatedLog10NormalAuxSampler",
     "ParetoAuxSampler",
     "PowerLawAuxSampler",
     "BrokenPowerLawAuxSampler",

--- a/popsynth/aux_samplers/plaw_aux_sampler.py
+++ b/popsynth/aux_samplers/plaw_aux_sampler.py
@@ -3,7 +3,7 @@ import numpy as np
 import scipy.stats as stats
 
 from popsynth.auxiliary_sampler import AuxiliaryParameter, AuxiliarySampler
-from popsynth.distributions.bpl_distribution import bpl
+from popsynth.distributions.bpl_distribution import sample_bpl
 
 
 class ParetoAuxSampler(AuxiliarySampler):
@@ -139,7 +139,7 @@ class BrokenPowerLawAuxSampler(AuxiliarySampler):
 
         u = np.atleast_1d(np.random.uniform(size=size))
 
-        self._true_values = bpl(
+        self._true_values = sample_bpl(
             u, self.xmin, self.xbreak, self.xmax, self.alpha, self.beta
         )
 

--- a/popsynth/aux_samplers/trunc_lognormal_aux_sampler.py
+++ b/popsynth/aux_samplers/trunc_lognormal_aux_sampler.py
@@ -41,7 +41,7 @@ class TruncatedLogNormalAuxSampler(AuxiliarySampler):
 
     def true_sampler(self, size: int):
 
-        if self.lower==0:
+        if self.lower == 0:
             a = stats.norm.ppf(1e-5, loc=self.mu, scale=self.tau)
         else:
             a = np.log(self.lower)

--- a/popsynth/aux_samplers/trunc_lognormal_aux_sampler.py
+++ b/popsynth/aux_samplers/trunc_lognormal_aux_sampler.py
@@ -9,14 +9,15 @@ class TruncatedLogNormalAuxSampler(AuxiliarySampler):
 
     mu = AuxiliaryParameter(default=0)
     tau = AuxiliaryParameter(default=1, vmin=0)
-    sigma = AuxiliaryParameter(default=1, vmin=0)
     lower = AuxiliaryParameter()
     upper = AuxiliaryParameter()
+    sigma = AuxiliaryParameter(default=1, vmin=0)
 
     def __init__(self, name: str, observed: bool = True):
         """
-        A Log normal sampler,
-        where property ~ e^N(``mu``, ``sigma``).
+        A truncated Log normal sampler,
+        where property ~ e^N(``mu``, ``sigma``), between
+        ``lower`` and ``upper``.
 
         :param name: Name of the property
         :type name: str
@@ -27,6 +28,10 @@ class TruncatedLogNormalAuxSampler(AuxiliarySampler):
         :type mu: :class:`AuxiliaryParameter`
         :param tau: Standard deviation of the lognormal
         :type tau: :class:`AuxiliaryParameter`
+        :param lower: Lower bound of the truncation
+        :type lower: :class:`AuxiliaryParameter`
+        :param upper: Upper bound of the truncation
+        :type upper: :class:`AuxiliaryParameter`
         :param sigma: Standard deviation of normal distribution
             from which observed values are sampled, if ``observed``
             is `True`
@@ -78,8 +83,9 @@ class TruncatedLog10NormalAuxSampler(AuxiliarySampler):
 
     def __init__(self, name: str, observed: bool = True):
         """
-        A Log10 normal sampler,
-        where property ~ 10^N(``mu``, ``sigma``).
+        A truncated Log10 normal sampler,
+        where property ~ 10^N(``mu``, ``sigma``), between
+        ``lower`` and ``upper``.
 
         :param name: Name of the property
         :type name: str
@@ -90,6 +96,10 @@ class TruncatedLog10NormalAuxSampler(AuxiliarySampler):
         :type mu: :class:`AuxiliaryParameter`
         :param tau: Standard deviation of the log10normal
         :type tau: :class:`AuxiliaryParameter`
+        :param lower: Lower bound of the truncation
+        :type lower: :class:`AuxiliaryParameter`
+        :param upper: Upper bound of the truncation
+        :type upper: :class:`AuxiliaryParameter`
         :param sigma: Standard deviation of normal distribution
             from which observed values are sampled, if ``observed``
             is `True`

--- a/popsynth/aux_samplers/trunc_lognormal_aux_sampler.py
+++ b/popsynth/aux_samplers/trunc_lognormal_aux_sampler.py
@@ -1,0 +1,133 @@
+import numpy as np
+import scipy.stats as stats
+
+from popsynth.auxiliary_sampler import AuxiliaryParameter, AuxiliarySampler
+
+
+class TruncatedLogNormalAuxSampler(AuxiliarySampler):
+    _auxiliary_sampler_name = "TruncatedLogNormalAuxSampler"
+
+    mu = AuxiliaryParameter(default=0)
+    tau = AuxiliaryParameter(default=1, vmin=0)
+    sigma = AuxiliaryParameter(default=1, vmin=0)
+    lower = AuxiliaryParameter()
+    upper = AuxiliaryParameter()
+
+    def __init__(self, name: str, observed: bool = True):
+        """
+        A Log normal sampler,
+        where property ~ e^N(``mu``, ``sigma``).
+
+        :param name: Name of the property
+        :type name: str
+        :param observed: `True` if the property is observed,
+            `False` if it is latent. Defaults to `True`
+        :type observed: bool
+        :param mu: Mean of the lognormal
+        :type mu: :class:`AuxiliaryParameter`
+        :param tau: Standard deviation of the lognormal
+        :type tau: :class:`AuxiliaryParameter`
+        :param sigma: Standard deviation of normal distribution
+            from which observed values are sampled, if ``observed``
+            is `True`
+        :type sigma: :class:`AuxiliaryParameter`
+        """
+        super(TruncatedLogNormalAuxSampler, self).__init__(name=name, observed=observed)
+
+    def true_sampler(self, size: int):
+        a = np.log(self.lower)
+        b = np.log(self.upper)
+
+        lower = (a - self.mu) / self.tau
+        upper = (b - self.mu) / self.tau
+
+        self._true_values = np.exp(
+            stats.truncnorm.rvs(
+                lower,
+                upper,
+                loc=self.mu,
+                scale=self.tau,
+                size=size,
+            )
+        )
+
+        assert np.alltrue(self._true_values >= self.lower)
+        assert np.alltrue(self._true_values <= self.upper)
+
+    def observation_sampler(self, size: int):
+
+        if self._is_observed:
+
+            self._obs_values = stats.norm.rvs(
+                loc=self._true_values, scale=self.sigma, size=size
+            )
+
+        else:
+
+            self._obs_values = self._true_values
+
+
+class TruncatedLog10NormalAuxSampler(AuxiliarySampler):
+    _auxiliary_sampler_name = "TruncatedLog10NormalAuxSampler"
+
+    mu = AuxiliaryParameter(default=0)
+    tau = AuxiliaryParameter(default=1, vmin=0)
+    sigma = AuxiliaryParameter(default=1, vmin=0)
+    lower = AuxiliaryParameter()
+    upper = AuxiliaryParameter()
+
+    def __init__(self, name: str, observed: bool = True):
+        """
+        A Log10 normal sampler,
+        where property ~ 10^N(``mu``, ``sigma``).
+
+        :param name: Name of the property
+        :type name: str
+        :param observed: `True` if the property is observed,
+            `False` if it is latent. Defaults to `True`
+        :type observed: bool
+        :param mu: Mean of the log10normal
+        :type mu: :class:`AuxiliaryParameter`
+        :param tau: Standard deviation of the log10normal
+        :type tau: :class:`AuxiliaryParameter`
+        :param sigma: Standard deviation of normal distribution
+            from which observed values are sampled, if ``observed``
+            is `True`
+        :type sigma: :class:`AuxiliaryParameter`
+        """
+        super(TruncatedLog10NormalAuxSampler, self).__init__(
+            name=name, observed=observed
+        )
+
+    def true_sampler(self, size: int):
+
+        a = np.log10(self.lower)
+        b = np.log10(self.upper)
+
+        lower = (a - self.mu) / self.tau
+        upper = (b - self.mu) / self.tau
+
+        self._true_values = np.power(
+            10, stats.truncnorm.rvs(
+                lower=lower,
+                upper=upper,
+                loc=self.mu,
+                scale=self.tau,
+                size=size,
+            )
+        )
+
+        assert np.alltrue(self._true_values >= self.lower)
+        assert np.alltrue(self._true_values <= self.upper)
+
+    def observation_sampler(self, size: int):
+
+        if self._is_observed:
+
+            self._obs_values = stats.norm.rvs(
+                loc=self._true_values, scale=self.sigma, size=size
+            )
+
+        else:
+
+            self._obs_values = self._true_values

--- a/popsynth/aux_samplers/trunc_lognormal_aux_sampler.py
+++ b/popsynth/aux_samplers/trunc_lognormal_aux_sampler.py
@@ -42,10 +42,10 @@ class TruncatedLogNormalAuxSampler(AuxiliarySampler):
     def true_sampler(self, size: int):
 
         if self.lower==0:
-            a = stats.norm.ppf(1e-5,loc=self.mu,scale=self.tau)
+            a = stats.norm.ppf(1e-5, loc=self.mu, scale=self.tau)
         else:
             a = np.log(self.lower)
-            
+
         b = np.log(self.upper)
 
         lower = (a - self.mu) / self.tau
@@ -116,7 +116,7 @@ class TruncatedLog10NormalAuxSampler(AuxiliarySampler):
 
     def true_sampler(self, size: int):
 
-        if self.lower==0:
+        if self.lower == 0:
             a = stats.norm.ppf(1e-5,loc=self.mu,scale=self.tau)
         else:
             a = np.log(self.lower)

--- a/popsynth/aux_samplers/trunc_lognormal_aux_sampler.py
+++ b/popsynth/aux_samplers/trunc_lognormal_aux_sampler.py
@@ -9,8 +9,8 @@ class TruncatedLogNormalAuxSampler(AuxiliarySampler):
 
     mu = AuxiliaryParameter(default=0)
     tau = AuxiliaryParameter(default=1, vmin=0)
-    lower = AuxiliaryParameter()
-    upper = AuxiliaryParameter()
+    lower = AuxiliaryParameter(vmin=0)
+    upper = AuxiliaryParameter(vmin=0)
     sigma = AuxiliaryParameter(default=1, vmin=0)
 
     def __init__(self, name: str, observed: bool = True):
@@ -40,7 +40,12 @@ class TruncatedLogNormalAuxSampler(AuxiliarySampler):
         super(TruncatedLogNormalAuxSampler, self).__init__(name=name, observed=observed)
 
     def true_sampler(self, size: int):
-        a = np.log(self.lower)
+
+        if self.lower==0:
+            a = stats.norm.ppf(1e-5,loc=self.mu,scale=self.tau)
+        else:
+            a = np.log(self.lower)
+            
         b = np.log(self.upper)
 
         lower = (a - self.mu) / self.tau
@@ -78,8 +83,8 @@ class TruncatedLog10NormalAuxSampler(AuxiliarySampler):
     mu = AuxiliaryParameter(default=0)
     tau = AuxiliaryParameter(default=1, vmin=0)
     sigma = AuxiliaryParameter(default=1, vmin=0)
-    lower = AuxiliaryParameter()
-    upper = AuxiliaryParameter()
+    lower = AuxiliaryParameter(vmin=0)
+    upper = AuxiliaryParameter(vmin=0)
 
     def __init__(self, name: str, observed: bool = True):
         """
@@ -111,7 +116,11 @@ class TruncatedLog10NormalAuxSampler(AuxiliarySampler):
 
     def true_sampler(self, size: int):
 
-        a = np.log10(self.lower)
+        if self.lower==0:
+            a = stats.norm.ppf(1e-5,loc=self.mu,scale=self.tau)
+        else:
+            a = np.log(self.lower)
+
         b = np.log10(self.upper)
 
         lower = (a - self.mu) / self.tau
@@ -119,8 +128,8 @@ class TruncatedLog10NormalAuxSampler(AuxiliarySampler):
 
         self._true_values = np.power(
             10, stats.truncnorm.rvs(
-                lower=lower,
-                upper=upper,
+                lower,
+                upper,
                 loc=self.mu,
                 scale=self.tau,
                 size=size,

--- a/popsynth/auxiliary_sampler.py
+++ b/popsynth/auxiliary_sampler.py
@@ -339,7 +339,7 @@ class AuxiliarySampler(
                 # quantities to derive a luminosity
                 # as it should be the last thing dervied
 
-                log.debug(f"{k} will have it spatial values set")
+                log.debug(f"{k} will have its spatial values set")
 
                 v.set_spatial_values(self._spatial_values)
 

--- a/popsynth/auxiliary_sampler.py
+++ b/popsynth/auxiliary_sampler.py
@@ -333,7 +333,9 @@ class AuxiliarySampler(
 
                 log.info(f"{self.name} is sampling its secondary quantities")
 
-            self._selector.set_distance(self._distance)
+            if self._uses_distance:
+
+                self._selector.set_distance(self._distance)
 
             try:
 

--- a/popsynth/distributions/cosmological_distribution.py
+++ b/popsynth/distributions/cosmological_distribution.py
@@ -50,7 +50,7 @@ class CosmologicalDistribution(SpatialDistribution):
 
         :param z: Redshift
         :returns: The differential comoving volume in
-            Gpc^-3 sr^-1.
+            Gpc^3 sr^-1.
         """
 
         return cosmology.differential_comoving_volume(z)

--- a/popsynth/population.py
+++ b/popsynth/population.py
@@ -1001,7 +1001,7 @@ class Population(object):
 
         ax.set_xlabel("distance")
         ax.set_ylabel("flux")
-        return fig 
+        return fig
 
     def display_obs_fluxes(self, ax=None, flux_color=dark, **kwargs):
         """

--- a/popsynth/population.py
+++ b/popsynth/population.py
@@ -869,6 +869,7 @@ class Population(object):
 
         ax.set_xlabel("distance")
         ax.set_ylabel("flux")
+        return fig 
 
     def display_obs_fluxes(self, ax=None, flux_color=dark, **kwargs):
         """

--- a/popsynth/population_synth.py
+++ b/popsynth/population_synth.py
@@ -818,7 +818,7 @@ class PopulationSynth(object, metaclass=ABCMeta):
 
         else:
 
-            log.error("This not an auxiliary sampler")
+            log.error("This is not an auxiliary sampler")
 
             raise RuntimeError()
 
@@ -893,7 +893,7 @@ class PopulationSynth(object, metaclass=ABCMeta):
 
     def draw_log_fobs(self, f, f_sigma, size=1) -> np.ndarray:
         """
-        Draw the log10 of the the fluxes.
+        Draw the log of the the fluxes.
         """
 
         log_f = np.log(f)

--- a/popsynth/population_synth.py
+++ b/popsynth/population_synth.py
@@ -502,7 +502,7 @@ class PopulationSynth(object, metaclass=ABCMeta):
 
         # we will gather them so that we can sort out dependencies
         aux_samplers: Dict[str, AuxiliarySampler] = OrderedDict()
-        secondary_samplers: [str, str] = OrderedDict()
+        secondary_samplers: Dict[str, str] = OrderedDict()
 
         if "auxiliary samplers" in input:
 


### PR DESCRIPTION
I added samplers for truncated log-normal and log10-normal distributions. 
I tested it but it might be good to add a test in test_aux_samplers.py too.